### PR TITLE
OP-3448 Style rules: consistent line breaks between args

### DIFF
--- a/rules/style.js
+++ b/rules/style.js
@@ -30,7 +30,7 @@ module.exports = {
         allowArrowFunctions: true,
       },
     ],
-    'function-paren-newline': 'error', // if newline inside function params, place newline between parentheses
+    'function-paren-newline': [ 'error', 'consistent' ], // if newline inside function params, place newline between each parameter argument
 
     'id-blacklist': 'off', // no blacklist for variable or function names
     'id-length': 'off', // no min or max identifier length


### PR DESCRIPTION
Changes:
- If you choose to use line breaks between parameters, then, do so for every parameter.

Ticket link:
https://openproject.veobot.io/projects/veo-software/work_packages/details/3448/
